### PR TITLE
fix: typo in makefile and imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ CFLAGS=-isysroot $(SDK)
 CFLAGS_IOKIT=$(CFLAGS) -framework IOKit -framework Foundation -framework Security -framework CoreFoundation 
 
 simple: 
-	$(CC) FileDP.m -o FileDP $(CFLAGS_IOKIT)
+	$(CC) main.m -o FileDP $(CFLAGS_IOKIT)
 

--- a/main.m
+++ b/main.m
@@ -1,4 +1,4 @@
-#import <Foundation/foundation.h>
+#import <Foundation/Foundation.h>
 #include <stdio.h>
 
 int main (int argc, const char * argv[]) 


### PR DESCRIPTION
Thanks for opening the source of FileDP! 
Found two little typos while building